### PR TITLE
extend the response to accept key and value

### DIFF
--- a/src/JsonDocumentPath.Test/JPathExecuteTests.cs
+++ b/src/JsonDocumentPath.Test/JPathExecuteTests.cs
@@ -75,6 +75,31 @@ namespace JDocument.Test
         }
 
         [Fact]
+        public void VerifyNameAndValue()
+        {
+            string json = @"{
+          ""persons"": [
+            {
+              ""name""  : ""John"",
+              ""age"": 26
+            },
+            {
+              ""name""  : ""Jane"",
+              ""age"": 2
+            }
+          ]
+        }";
+
+            var models = JsonDocument.Parse(json).RootElement;
+
+            var results = models.SelectExtElements("persons[*].name").ToList();
+
+            Assert.Equal(2, results.Count);
+            Assert.Equal("John", results[0].Element.ToString());
+            Assert.Equal("name", results[0].Name);
+        }
+
+        [Fact]
         public void RecursiveWildcard()
         {
             string json = @"{
@@ -572,7 +597,7 @@ namespace JDocument.Test
                 }";
             var document = JsonDocument.Parse(json).RootElement;
 
-            ExceptionAssert.Throws<JsonException>(() => { document.SelectElement("[*]", true); }, @"Index * not valid on JsonElement.");
+            ExceptionAssert.Throws<JsonException>(() => { document.SelectElement("[*]", true); }, @"Index * not valid on JsonElementExt.");
         }
 
         [Fact]
@@ -583,7 +608,7 @@ namespace JDocument.Test
                 }";
             var document = JsonDocument.Parse(json).RootElement;
 
-            ExceptionAssert.Throws<JsonException>(() => { document.SelectElement("[:]", true); }, @"Array slice is not valid on JsonElement.");
+            ExceptionAssert.Throws<JsonException>(() => { document.SelectElement("[:]", true); }, @"Array slice is not valid on JsonElementExt.");
         }
 
         [Fact]
@@ -610,7 +635,7 @@ namespace JDocument.Test
             string json = @"[1,2,3,4,5]";
             var document = JsonDocument.Parse(json).RootElement;
 
-            ExceptionAssert.Throws<JsonException>(() => { document.SelectElement("BlahBlah", true); }, @"Property 'BlahBlah' not valid on JsonElement.");
+            ExceptionAssert.Throws<JsonException>(() => { document.SelectElement("BlahBlah", true); }, @"Property 'BlahBlah' not valid on JsonElementExt.");
         }
 
         [Fact]
@@ -661,7 +686,7 @@ namespace JDocument.Test
         {
             var a = JsonDocument.Parse("[1,2,3,4,5]").RootElement;
 
-            ExceptionAssert.Throws<JsonException>(() => { a.SelectElement("['Missing','Missing2']", true); }, "Properties 'Missing', 'Missing2' not valid on JsonElement.");
+            ExceptionAssert.Throws<JsonException>(() => { a.SelectElement("['Missing','Missing2']", true); }, "Properties 'Missing', 'Missing2' not valid on JsonElementExt.");
         }
 
         [Fact]

--- a/src/JsonDocumentPath/Filters/ArrayIndexFilter.cs
+++ b/src/JsonDocumentPath/Filters/ArrayIndexFilter.cs
@@ -6,13 +6,13 @@ namespace System.Text.Json
     {
         public int? Index { get; set; }
 
-        public override IEnumerable<JsonElement?> ExecuteFilter(JsonElement root, IEnumerable<JsonElement?> current, bool errorWhenNoMatch)
+        public override IEnumerable<JsonElementExt> ExecuteFilter(JsonElement root, IEnumerable<JsonElementExt> current, bool errorWhenNoMatch)
         {
-            foreach (JsonElement t in current)
+            foreach (JsonElementExt t in current)
             {
                 if (Index != null)
                 {
-                    JsonElement? v = GetTokenIndex(t, errorWhenNoMatch, Index.GetValueOrDefault());
+                    JsonElementExt v = GetTokenIndex(t.Element.Value, errorWhenNoMatch, Index.GetValueOrDefault());
 
                     if (v != null)
                     {
@@ -21,11 +21,11 @@ namespace System.Text.Json
                 }
                 else
                 {
-                    if (t.ValueKind == JsonValueKind.Array)
+                    if (t.Element?.ValueKind == JsonValueKind.Array)
                     {
-                        foreach (JsonElement v in t.EnumerateArray())
+                        foreach (JsonElement v in t.Element.Value.EnumerateArray())
                         {
-                            yield return v;
+                            yield return new JsonElementExt{ Element = v };
                         }
                     }
                     else

--- a/src/JsonDocumentPath/Filters/ArrayMultipleIndexFilter.cs
+++ b/src/JsonDocumentPath/Filters/ArrayMultipleIndexFilter.cs
@@ -11,13 +11,13 @@ namespace System.Text.Json
             Indexes = indexes;
         }
 
-        public override IEnumerable<JsonElement?> ExecuteFilter(JsonElement root, IEnumerable<JsonElement?> current, bool errorWhenNoMatch)
+        public override IEnumerable<JsonElementExt> ExecuteFilter(JsonElement root, IEnumerable<JsonElementExt> current, bool errorWhenNoMatch)
         {
-            foreach (JsonElement t in current)
+            foreach (JsonElementExt t in current)
             {
                 foreach (int i in Indexes)
                 {
-                    JsonElement? v = GetTokenIndex(t, errorWhenNoMatch, i);
+                    JsonElementExt v = GetTokenIndex(t.Element.Value, errorWhenNoMatch, i);
 
                     if (v != null)
                     {

--- a/src/JsonDocumentPath/Filters/ArraySliceFilter.cs
+++ b/src/JsonDocumentPath/Filters/ArraySliceFilter.cs
@@ -8,18 +8,18 @@ namespace System.Text.Json
         public int? End { get; set; }
         public int? Step { get; set; }
 
-        public override IEnumerable<JsonElement?> ExecuteFilter(JsonElement root, IEnumerable<JsonElement?> current, bool errorWhenNoMatch)
+        public override IEnumerable<JsonElementExt> ExecuteFilter(JsonElement root, IEnumerable<JsonElementExt> current, bool errorWhenNoMatch)
         {
             if (Step == 0)
             {
                 throw new JsonException("Step cannot be zero.");
             }
 
-            foreach (JsonElement t in current)
+            foreach (JsonElementExt t in current)
             {
-                if (t.ValueKind == JsonValueKind.Array)
+                if (t.Element.Value.ValueKind == JsonValueKind.Array)
                 {
-                    var aCount = t.GetArrayLength();
+                    var aCount = t.Element.Value.GetArrayLength();
                     // set defaults for null arguments
                     int stepCount = Step ?? 1;
                     int startIndex = Start ?? ((stepCount > 0) ? 0 : aCount - 1);
@@ -49,7 +49,7 @@ namespace System.Text.Json
                     {
                         for (int i = startIndex; IsValid(i, stopIndex, positiveStep); i += stepCount)
                         {
-                            yield return t[i];
+                            yield return new JsonElementExt(){ Element = t.Element.Value[i] };
                         }
                     }
                     else

--- a/src/JsonDocumentPath/Filters/FieldFilter.cs
+++ b/src/JsonDocumentPath/Filters/FieldFilter.cs
@@ -4,26 +4,26 @@ namespace System.Text.Json
 {
     internal class FieldFilter : PathFilter
     {
-        internal string? Name;
+        internal string Name;
 
-        public FieldFilter(string? name)
+        public FieldFilter(string name)
         {
             Name = name;
         }
 
-        public override IEnumerable<JsonElement?> ExecuteFilter(JsonElement root, IEnumerable<JsonElement?> current, bool errorWhenNoMatch)
+        public override IEnumerable<JsonElementExt> ExecuteFilter(JsonElement root, IEnumerable<JsonElementExt> current, bool errorWhenNoMatch)
         {
-            foreach (JsonElement t in current)
+            foreach (JsonElementExt t in current)
             {
-                if (t.ValueKind == JsonValueKind.Object)
+                if (t.Element.Value.ValueKind == JsonValueKind.Object)
                 {
                     if (Name != null)
                     {
-                        if (t.TryGetProperty(Name, out JsonElement v))
+                        if (t.Element.Value.TryGetProperty(Name, out JsonElement v))
                         {
                             if (v.ValueKind != JsonValueKind.Null)
                             {
-                                yield return v;
+                                yield return new JsonElementExt(){Element = v, Name =Name };
                             }
                             else if (errorWhenNoMatch)
                             {
@@ -33,9 +33,9 @@ namespace System.Text.Json
                     }
                     else
                     {
-                        foreach (var p in t.ChildrenTokens())
+                        foreach (var p in t.Element.Value.ChildrenTokens())
                         {
-                            yield return p;
+                            yield return new JsonElementExt() {Element = p};
                         }
                     }
                 }

--- a/src/JsonDocumentPath/Filters/FieldMultipleFilter.cs
+++ b/src/JsonDocumentPath/Filters/FieldMultipleFilter.cs
@@ -12,19 +12,19 @@ namespace System.Text.Json
             Names = names;
         }
 
-        public override IEnumerable<JsonElement?> ExecuteFilter(JsonElement root, IEnumerable<JsonElement?> current, bool errorWhenNoMatch)
+        public override IEnumerable<JsonElementExt> ExecuteFilter(JsonElement root, IEnumerable<JsonElementExt> current, bool errorWhenNoMatch)
         {
-            foreach (JsonElement t in current)
+            foreach (JsonElementExt t in current)
             {
-                if (t.ValueKind == JsonValueKind.Object)
+                if (t.Element.Value.ValueKind == JsonValueKind.Object)
                 {
                     foreach (string name in Names)
                     {
-                        if (t.TryGetProperty(name, out JsonElement v))
+                        if (t.Element.Value.TryGetProperty(name, out JsonElement v))
                         {
                             if (v.ValueKind != JsonValueKind.Null)
                             {
-                                yield return v;
+                                yield return new JsonElementExt(){ Element = v, Name = name };
                             }
                             else if (errorWhenNoMatch)
                             {

--- a/src/JsonDocumentPath/Filters/QueryFilter.cs
+++ b/src/JsonDocumentPath/Filters/QueryFilter.cs
@@ -11,27 +11,27 @@ namespace System.Text.Json
             Expression = expression;
         }
 
-        public override IEnumerable<JsonElement?> ExecuteFilter(JsonElement root, IEnumerable<JsonElement?> current, bool errorWhenNoMatch)
+        public override IEnumerable<JsonElementExt> ExecuteFilter(JsonElement root, IEnumerable<JsonElementExt> current, bool errorWhenNoMatch)
         {
-            foreach (JsonElement el in current)
+            foreach (JsonElementExt el in current)
             {
-                if (el.ValueKind == JsonValueKind.Array)
+                if (el.Element.Value.ValueKind == JsonValueKind.Array)
                 {
-                    foreach (JsonElement v in el.EnumerateArray())
+                    foreach (JsonElement v in el.Element.Value.EnumerateArray())
                     {
                         if (Expression.IsMatch(root, v))
                         {
-                            yield return v;
+                            yield return new JsonElementExt(){ Element = v };
                         }
                     }
                 }
-                else if (el.ValueKind == JsonValueKind.Object)
+                else if (el.Element.Value.ValueKind == JsonValueKind.Object)
                 {
-                    foreach (JsonProperty v in el.EnumerateObject())
+                    foreach (JsonProperty v in el.Element.Value.EnumerateObject())
                     {
                         if (Expression.IsMatch(root, v.Value))
                         {
-                            yield return v.Value;
+                            yield return new JsonElementExt(){ Element = v.Value, Name = v.Name };
                         }
                     }
                 }

--- a/src/JsonDocumentPath/Filters/QueryScanFilter.cs
+++ b/src/JsonDocumentPath/Filters/QueryScanFilter.cs
@@ -11,15 +11,15 @@ namespace System.Text.Json
             Expression = expression;
         }
 
-        public override IEnumerable<JsonElement?> ExecuteFilter(JsonElement root, IEnumerable<JsonElement?> current, bool errorWhenNoMatch)
+        public override IEnumerable<JsonElementExt> ExecuteFilter(JsonElement root, IEnumerable<JsonElementExt> current, bool errorWhenNoMatch)
         {
-            foreach (JsonElement t in current)
+            foreach (JsonElementExt t in current)
             {
-                foreach (var (_, Value) in GetNextScanValue(t))
+                foreach (var (name, v) in GetNextScanValue(t))
                 {
-                    if (Expression.IsMatch(root, Value))
+                    if (Expression.IsMatch(root, v.Element.Value))
                     {
-                        yield return Value;
+                        yield return new JsonElementExt(){ Element = v.Element, Name = name };
                     }
                 }
             }

--- a/src/JsonDocumentPath/Filters/RootFilter.cs
+++ b/src/JsonDocumentPath/Filters/RootFilter.cs
@@ -10,9 +10,15 @@ namespace System.Text.Json
         {
         }
 
-        public override IEnumerable<JsonElement?> ExecuteFilter(JsonElement root, IEnumerable<JsonElement?> current, bool errorWhenNoMatch)
+        public override IEnumerable<JsonElementExt> ExecuteFilter(JsonElement root, IEnumerable<JsonElementExt> current, bool errorWhenNoMatch)
         {
-            return new JsonElement?[1] { root };
+            return new List<JsonElementExt>()
+            {
+                new JsonElementExt()
+                {
+                     Element = root
+                }
+            };
         }
     }
 }

--- a/src/JsonDocumentPath/Filters/ScanFilter.cs
+++ b/src/JsonDocumentPath/Filters/ScanFilter.cs
@@ -12,9 +12,9 @@ namespace System.Text.Json
             Name = name;
         }
 
-        public override IEnumerable<JsonElement?> ExecuteFilter(JsonElement root, IEnumerable<JsonElement?> current, bool errorWhenNoMatch)
+        public override IEnumerable<JsonElementExt> ExecuteFilter(JsonElement root, IEnumerable<JsonElementExt> current, bool errorWhenNoMatch)
         {
-            foreach (JsonElement c in current)
+            foreach (JsonElementExt c in current)
             {
                 foreach (var e in GetNextScanValue(c))
                 {

--- a/src/JsonDocumentPath/Filters/ScanMultipleFilter.cs
+++ b/src/JsonDocumentPath/Filters/ScanMultipleFilter.cs
@@ -11,12 +11,10 @@ namespace System.Text.Json
             _names = names;
         }
 
-        public override IEnumerable<JsonElement?> ExecuteFilter(JsonElement root, IEnumerable<JsonElement?> current, bool errorWhenNoMatch)
+        public override IEnumerable<JsonElementExt> ExecuteFilter(JsonElement root, IEnumerable<JsonElementExt> current, bool errorWhenNoMatch)
         {
-            foreach (JsonElement c in current)
+            foreach (JsonElementExt c in current)
             {
-                JsonElement? value = c;
-
                 foreach (var e in GetNextScanValue(c))
                 {
                     if (e.Name != null)
@@ -25,7 +23,7 @@ namespace System.Text.Json
                         {
                             if (e.Name == name)
                             {
-                                yield return e.Value;
+                                yield return new JsonElementExt(){ Element = e.Value.Element, Name = e.Name };
                             }
                         }
                     }

--- a/src/JsonDocumentPath/JsonDocumentPath.cs
+++ b/src/JsonDocumentPath/JsonDocumentPath.cs
@@ -897,14 +897,15 @@ namespace System.Text.Json
             }
         }
 
-        internal IEnumerable<JsonElement?> Evaluate(JsonElement root, JsonElement t, bool errorWhenNoMatch)
+        internal IEnumerable<JsonElementExt> Evaluate(JsonElement root, JsonElement t, bool errorWhenNoMatch)
         {
             return Evaluate(Filters, root, t, errorWhenNoMatch);
         }
 
-        internal static IEnumerable<JsonElement?> Evaluate(List<PathFilter> filters, JsonElement root, JsonElement t, bool errorWhenNoMatch)
+        internal static IEnumerable<JsonElementExt> Evaluate(List<PathFilter> filters, JsonElement root, JsonElement t, bool errorWhenNoMatch)
         {
-            IEnumerable<JsonElement?> current = new JsonElement?[] { t };
+            IEnumerable<JsonElementExt> current = new [] { new JsonElementExt{ Element = t }};
+
             foreach (PathFilter filter in filters)
             {
                 current = filter.ExecuteFilter(root, current, errorWhenNoMatch);

--- a/src/JsonDocumentPath/JsonDocumentPathExtensions.cs
+++ b/src/JsonDocumentPath/JsonDocumentPathExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 
 namespace System.Text.Json
 {
@@ -23,6 +24,19 @@ namespace System.Text.Json
         /// <param name="path">
         /// A <see cref="String"/> that contains a JSONPath expression.
         /// </param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="JsonDocument"/> that contains the selected elements.</returns>
+
+        public static IEnumerable<JsonElementExt> SelectExtElements(this JsonDocument src, string path)
+        {
+            return SelectExtElements(src.RootElement, path, false);
+        }
+
+        /// <summary>
+        /// Selects a collection of elements using a JSONPath expression.
+        /// </summary>
+        /// <param name="path">
+        /// A <see cref="String"/> that contains a JSONPath expression.
+        /// </param>
         /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="JsonElement"/> that contains the selected elements.</returns>
 
         public static IEnumerable<JsonElement?> SelectElements(this JsonElement src, string path)
@@ -36,9 +50,36 @@ namespace System.Text.Json
         /// <param name="path">
         /// A <see cref="String"/> that contains a JSONPath expression.
         /// </param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="JsonElementExt"/> that contains the selected elements.</returns>
+
+        public static IEnumerable<JsonElementExt> SelectExtElements(this JsonElement src, string path)
+        {
+            return SelectExtElements(src, path, false);
+        }
+
+        /// <summary>
+        /// Selects a collection of elements using a JSONPath expression.
+        /// </summary>
+        /// <param name="path">
+        /// A <see cref="String"/> that contains a JSONPath expression.
+        /// </param>
         /// <param name="errorWhenNoMatch">A flag to indicate whether an error should be thrown if no tokens are found when evaluating part of the expression.</param>
         /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="JsonElement"/> that contains the selected elements.</returns>
         public static IEnumerable<JsonElement?> SelectElements(this JsonElement src, string path, bool errorWhenNoMatch)
+        {
+            var parser = new JsonDocumentPath(path);
+            return parser.Evaluate(src, src, errorWhenNoMatch).Select(x=>x.Element);
+        }
+
+        /// <summary>
+        /// Selects a collection of elements using a JSONPath expression.
+        /// </summary>
+        /// <param name="path">
+        /// A <see cref="String"/> that contains a JSONPath expression.
+        /// </param>
+        /// <param name="errorWhenNoMatch">A flag to indicate whether an error should be thrown if no tokens are found when evaluating part of the expression.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="JsonElementExt"/> that contains the selected elements.</returns>
+        public static IEnumerable<JsonElementExt> SelectExtElements(this JsonElement src, string path, bool errorWhenNoMatch)
         {
             var parser = new JsonDocumentPath(path);
             return parser.Evaluate(src, src, errorWhenNoMatch);
@@ -53,6 +94,20 @@ namespace System.Text.Json
         /// <param name="errorWhenNoMatch">A flag to indicate whether an error should be thrown if no tokens are found when evaluating part of the expression.</param>
         /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="JsonDocument"/> that contains the selected elements.</returns>
         public static IEnumerable<JsonElement?> SelectElements(this JsonDocument src, string path, bool errorWhenNoMatch)
+        {
+            var parser = new JsonDocumentPath(path);
+            return parser.Evaluate(src.RootElement, src.RootElement, errorWhenNoMatch).Select(x=>x.Element);
+        }
+
+        /// <summary>
+        /// Selects a collection of elements using a JSONPath expression.
+        /// </summary>
+        /// <param name="path">
+        /// A <see cref="String"/> that contains a JSONPath expression.
+        /// </param>
+        /// <param name="errorWhenNoMatch">A flag to indicate whether an error should be thrown if no tokens are found when evaluating part of the expression.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="JsonDocument"/> that contains the selected elements.</returns>
+        public static IEnumerable<JsonElementExt> SelectExtElements(this JsonDocument src, string path, bool errorWhenNoMatch)
         {
             var parser = new JsonDocumentPath(path);
             return parser.Evaluate(src.RootElement, src.RootElement, errorWhenNoMatch);
@@ -71,6 +126,18 @@ namespace System.Text.Json
         }
 
         /// <summary>
+        /// Selects a <see cref="JsonElementExt"/> using a JSONPath expression. Selects the token that matches the object path.
+        /// </summary>
+        /// <param name="path">
+        /// A <see cref="String"/> that contains a JSONPath expression.
+        /// </param>
+        /// <returns>A <see cref="JsonDocument"/>, or <c>null</c>.</returns>
+        public static JsonElementExt SelectExtElement(this JsonDocument src, string path)
+        {
+            return SelectExtElement(src.RootElement, path, false);
+        }
+
+        /// <summary>
         /// Selects a <see cref="JsonElement"/> using a JSONPath expression. Selects the token that matches the object path.
         /// </summary>
         /// <param name="path">
@@ -80,6 +147,18 @@ namespace System.Text.Json
         public static JsonElement? SelectElement(this JsonElement src, string path)
         {
             return SelectElement(src, path, false);
+        }
+
+        /// <summary>
+        /// Selects a <see cref="JsonElementExt"/> using a JSONPath expression. Selects the token that matches the object path.
+        /// </summary>
+        /// <param name="path">
+        /// A <see cref="String"/> that contains a JSONPath expression.
+        /// </param>
+        /// <returns>A <see cref="JsonElementExt"/>, or <c>null</c>.</returns>
+        public static JsonElementExt SelectExtElement(this JsonElement src, string path)
+        {
+            return SelectExtElement(src, path, false);
         }
 
         /// <summary>
@@ -93,8 +172,31 @@ namespace System.Text.Json
         public static JsonElement? SelectElement(this JsonDocument src, string path, bool errorWhenNoMatch)
         {
             var p = new JsonDocumentPath(path);
-            JsonElement? el = null;
-            foreach (JsonElement t in p.Evaluate(src.RootElement, src.RootElement, errorWhenNoMatch))
+            JsonElementExt el = null;
+            foreach (JsonElementExt t in p.Evaluate(src.RootElement, src.RootElement, errorWhenNoMatch))
+            {
+                if (el != null)
+                {
+                    throw new JsonException("Path returned multiple tokens.");
+                }
+                el = t;
+            }
+            return el.Element;
+        }
+
+        /// <summary>
+        /// Selects a <see cref="JsonElementExt"/> using a JSONPath expression. Selects the token that matches the object path.
+        /// </summary>
+        /// <param name="path">
+        /// A <see cref="String"/> that contains a JSONPath expression.
+        /// </param>
+        /// <param name="errorWhenNoMatch">A flag to indicate whether an error should be thrown if no tokens are found when evaluating part of the expression.</param>
+        /// <returns>A <see cref="JsonDocument"/>.</returns>
+        public static JsonElementExt SelectExtElement(this JsonDocument src, string path, bool errorWhenNoMatch)
+        {
+            var p = new JsonDocumentPath(path);
+            JsonElementExt el = null;
+            foreach (JsonElementExt t in p.Evaluate(src.RootElement, src.RootElement, errorWhenNoMatch))
             {
                 if (el != null)
                 {
@@ -116,8 +218,31 @@ namespace System.Text.Json
         public static JsonElement? SelectElement(this JsonElement src, string path, bool errorWhenNoMatch)
         {
             var p = new JsonDocumentPath(path);
-            JsonElement? el = null;
-            foreach (JsonElement t in p.Evaluate(src, src, errorWhenNoMatch))
+            JsonElementExt el = null;
+            foreach (JsonElementExt t in p.Evaluate(src, src, errorWhenNoMatch))
+            {
+                if (el != null)
+                {
+                    throw new JsonException("Path returned multiple tokens.");
+                }
+                el = t;
+            }
+            return el?.Element;
+        }
+
+        /// <summary>
+        /// Selects a <see cref="JsonElementExt"/> using a JSONPath expression. Selects the token that matches the object path.
+        /// </summary>
+        /// <param name="path">
+        /// A <see cref="String"/> that contains a JSONPath expression.
+        /// </param>
+        /// <param name="errorWhenNoMatch">A flag to indicate whether an error should be thrown if no tokens are found when evaluating part of the expression.</param>
+        /// <returns>A <see cref="JsonElementExt"/>.</returns>
+        public static JsonElementExt SelectExtElement(this JsonElement src, string path, bool errorWhenNoMatch)
+        {
+            var p = new JsonDocumentPath(path);
+            JsonElementExt el = null;
+            foreach (JsonElementExt t in p.Evaluate(src, src, errorWhenNoMatch))
             {
                 if (el != null)
                 {

--- a/src/JsonDocumentPath/JsonElementExt.cs
+++ b/src/JsonDocumentPath/JsonElementExt.cs
@@ -1,0 +1,9 @@
+﻿namespace System.Text.Json
+{
+    public class JsonElementExt
+    {
+        public JsonElement? Element { get; set; }
+
+        public string Name { get; set; }
+    }
+}

--- a/src/JsonDocumentPath/PathFilter.cs
+++ b/src/JsonDocumentPath/PathFilter.cs
@@ -4,9 +4,9 @@ namespace System.Text.Json
 {
     public abstract class PathFilter
     {
-        public abstract IEnumerable<JsonElement?> ExecuteFilter(JsonElement root, IEnumerable<JsonElement?> current, bool errorWhenNoMatch);
+        public abstract IEnumerable<JsonElementExt> ExecuteFilter(JsonElement root, IEnumerable<JsonElementExt> current, bool errorWhenNoMatch);
 
-        protected static JsonElement? GetTokenIndex(JsonElement t, bool errorWhenNoMatch, int index)
+        protected static JsonElementExt GetTokenIndex(JsonElement t, bool errorWhenNoMatch, int index)
         {
             if (t.ValueKind == JsonValueKind.Array)
             {
@@ -20,7 +20,7 @@ namespace System.Text.Json
                     return null;
                 }
 
-                return t[index];
+                return new JsonElementExt() {Element = t[index]};
             }
             else
             {
@@ -33,27 +33,27 @@ namespace System.Text.Json
             }
         }
 
-        protected static IEnumerable<(string Name, JsonElement Value)> GetNextScanValue(JsonElement value)
+        protected static IEnumerable<(string Name, JsonElementExt Value)> GetNextScanValue(JsonElementExt value)
         {
             yield return (null, value);
 
-            if (value.ValueKind == JsonValueKind.Array)
+            if (value.Element?.ValueKind == JsonValueKind.Array)
             {
-                foreach (var e in value.EnumerateArray())
+                foreach (var e in value.Element?.EnumerateArray())
                 {
-                    foreach (var c in GetNextScanValue(e))
+                    foreach (var c in GetNextScanValue(new JsonElementExt(){ Element = e }))
                     {
                         yield return c;
                     }
                 }
             }
-            else if (value.ValueKind == JsonValueKind.Object)
+            else if (value.Element?.ValueKind == JsonValueKind.Object)
             {
-                foreach (var e in value.EnumerateObject())
+                foreach (var e in value.Element?.EnumerateObject())
                 {
-                    yield return (e.Name, e.Value);
+                    yield return (e.Name, new JsonElementExt{Element = e.Value, Name = e.Name });
 
-                    foreach (var c in GetNextScanValue(e.Value))
+                    foreach (var c in GetNextScanValue(new JsonElementExt(){ Element = e.Value }))
                     {
                         yield return c;
                     }

--- a/src/JsonDocumentPath/QueryExpression.cs
+++ b/src/JsonDocumentPath/QueryExpression.cs
@@ -81,11 +81,11 @@ namespace System.Text.Json
             Right = right;
         }
 
-        private IEnumerable<JsonElement?> GetResult(JsonElement root, JsonElement t, object? o)
+        private IEnumerable<JsonElementExt> GetResult(JsonElement root, JsonElement t, object? o)
         {
             if (o is JsonElement resultToken)
             {
-                return new JsonElement?[1] { resultToken };
+                return new JsonElementExt[1] { new JsonElementExt(){ Element=resultToken } };
             }
 
             if (o is List<PathFilter> pathFilters)
@@ -93,7 +93,7 @@ namespace System.Text.Json
                 return JsonDocumentPath.Evaluate(pathFilters, root, t, false);
             }
 
-            return Enumerable.Empty<JsonElement?>();
+            return Enumerable.Empty<JsonElementExt>();
         }
 
         public override bool IsMatch(JsonElement root, JsonElement t)
@@ -103,19 +103,19 @@ namespace System.Text.Json
                 return GetResult(root, t, Left).Any();
             }
 
-            using (IEnumerator<JsonElement?> leftResults = GetResult(root, t, Left).GetEnumerator())
+            using (IEnumerator<JsonElementExt> leftResults = GetResult(root, t, Left).GetEnumerator())
             {
                 if (leftResults.MoveNext())
                 {
-                    IEnumerable<JsonElement?> rightResultsEn = GetResult(root, t, Right);
-                    ICollection<JsonElement?> rightResults = rightResultsEn as ICollection<JsonElement?> ?? rightResultsEn.ToList();
+                    IEnumerable<JsonElementExt> rightResultsEn = GetResult(root, t, Right);
+                    ICollection<JsonElementExt> rightResults = rightResultsEn as ICollection<JsonElementExt> ?? rightResultsEn.ToList();
 
                     do
                     {
-                        JsonElement leftResult = leftResults.Current.Value;
-                        foreach (JsonElement rightResult in rightResults)
+                        JsonElement? leftResult = leftResults.Current.Element;
+                        foreach (JsonElementExt rightResult in rightResults)
                         {
-                            if (MatchTokens(leftResult, rightResult))
+                            if (MatchTokens(leftResult.Value, rightResult.Element.Value))
                             {
                                 return true;
                             }


### PR DESCRIPTION
extend the response to JsonElementExt, including name and value.

`{
    "persons": [
        {
            "name": "John",
            "age": 26
        },
        {
            "name": "Jane",
            "age": 2
        }
    ]
}`

`var models = JsonDocument.Parse(json).RootElement;`
`var results = models.SelectExtElements("persons[*].name").ToList();`

the results should be
`[
    {
        "Element": "John",
        "Name": "name"
    },
    {
        "Element": "Jane",
        "Name": "name"
    }
]`